### PR TITLE
ci: setup goreleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ wwhrd
 wwhrd.exe
 
 .cover
+
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,17 @@
+---
+project_name: wwhrd
+builds:
+- goos:
+  - linux
+  - darwin
+  - windows
+  goarch:
+  - amd64
+archive:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+  format: tar.gz
+  files:
+  - LICENSE*
+  - README*
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_checksums.txt'

--- a/cli.go
+++ b/cli.go
@@ -9,8 +9,9 @@ import (
 )
 
 type cliOpts struct {
-	List  `command:"list" alias:"ls" description:"List licenses"`
-	Check `command:"check" alias:"chk" description:"Check licenses against config file"`
+	List        `command:"list" alias:"ls" description:"List licenses"`
+	Check       `command:"check" alias:"chk" description:"Check licenses against config file"`
+	VersionFlag func() error `long:"version" short:"v" description:"Show CLI version"`
 }
 
 type List struct {
@@ -20,8 +21,23 @@ type Check struct {
 	File string `short:"f" long:"file" description:"input file" default:".wwhrd.yml"`
 }
 
+const VersionHelp flags.ErrorType = 1961
+
+var (
+	version = "dev"
+	commit  = "1961213"
+	date    = "1961-02-13T20:06:35Z"
+)
+
 func newCli() *flags.Parser {
-	var opts cliOpts
+	opts := cliOpts{
+		VersionFlag: func() error {
+			return &flags.Error{
+				Type:    VersionHelp,
+				Message: fmt.Sprintf("version %s\ncommit %s\ndate %s\n", version, commit, date),
+			}
+		},
+	}
 	parser := flags.NewParser(&opts, flags.HelpFlag|flags.PassDoubleDash)
 	parser.LongDescription = "What would Henry Rollins do?"
 

--- a/wwhrd.go
+++ b/wwhrd.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/jessevdk/go-flags"
@@ -15,6 +16,8 @@ func main() {
 		if _, ok := err.(*flags.Error); ok {
 			typ := err.(*flags.Error).Type
 			switch {
+			case typ == VersionHelp:
+				fmt.Println(err.(*flags.Error).Message)
 			case typ == flags.ErrHelp:
 				parser.WriteHelp(os.Stdout)
 			case typ == flags.ErrCommandRequired && len(c[0]) == 0:


### PR DESCRIPTION
In theory this commit has all the magic to wire this tool up for [Goreleaser](https://goreleaser.com/).

Which would make it easy for you guys to publish and cut a release, publish artifacts, or even let us use [Godownloader](https://github.com/goreleaser/godownloader) to use this tool in our CI processes.

Part of this work also involved hacking up a little version flag. I'm not real familiar with `jessevdk/go-flags` so I just stole how `bosh-cli` achieved this:

- [VersionOpt function](https://github.com/cloudfoundry/bosh-cli/blob/06eede24ca808e599a73fd38251ed84d0c506e07/cmd/factory.go#L27-L32)
- [VersionOpt option](https://github.com/cloudfoundry/bosh-cli/blob/e94aeebdeed26c840d96c33a02126f523d7b226a/cmd/opts.go#L14)

Because it seems like the idea of a `VersionFlag` (like the [HelpFlag](https://github.com/jessevdk/go-flags/blob/3153d14e61b5ec4161ffd7b3fd8da0e9e27ed8f3/parser.go#L86-L91)) isn't a thing:

- https://github.com/jessevdk/go-flags/issues/204
- https://github.com/jessevdk/go-flags/issues/250

Mostly just wanted to say thanks for all the work ya'll put into this - it's a nifty little tool.
