### PR TITLE
fix: disable cgo to protect against future broken docker releases.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,8 @@ builds:
   - windows
   goarch:
   - amd64
+  env:
+  - CGO_ENABLED=0
 archive:
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
   format: tar.gz


### PR DESCRIPTION
This should enable you to continue to use `FROM: scratch` when eventually your application silently begins dynamically linking against shared C libraries which will be absent from the scratch container but present in the golang container that the application is built in.

I just spent 2 hours learning about this and thought I'd save you from a future of silently broken Docker releases.