### PR TITLE
Warn on unrecognized licenses in list mode

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -60,11 +60,16 @@ func (l *List) Execute(args []string) error {
 	lics := GetLicenses(root, pkgs)
 
 	for k, v := range lics {
-
-		log.WithFields(log.Fields{
-			"package": k,
-			"license": v.Type,
-		}).Info("Found License")
+		if v.Recognized() {
+			log.WithFields(log.Fields{
+				"package": k,
+				"license": v.Type,
+			}).Info("Found License")
+		} else {
+			log.WithFields(log.Fields{
+				"package": k,
+			}).Warning("Did not find recognized license!")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Currently when running `wwhrd list`, if there is no license, or if it is not recognized, it is reported on info-level as "Found License license=unrecognized". This PR changes the log level to warn in this case, so that it stands out in a longer listing.