### PR TITLE
Add a quiet flag

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -12,6 +12,8 @@ type cliOpts struct {
 	List        `command:"list" alias:"ls" description:"List licenses"`
 	Check       `command:"check" alias:"chk" description:"Check licenses against config file"`
 	VersionFlag func() error `long:"version" short:"v" description:"Show CLI version"`
+
+	Quiet func() error `short:"q" long:"quiet" description:"quiet mode, do not log accepted packages"`
 }
 
 type List struct {
@@ -36,6 +38,10 @@ func newCli() *flags.Parser {
 				Type:    VersionHelp,
 				Message: fmt.Sprintf("version %s\ncommit %s\ndate %s\n", version, commit, date),
 			}
+		},
+		Quiet: func() error {
+			log.SetLevel(log.WarnLevel)
+			return nil
 		},
 	}
 	parser := flags.NewParser(&opts, flags.HelpFlag|flags.PassDoubleDash)

--- a/cli.go
+++ b/cli.go
@@ -31,6 +31,11 @@ var (
 	date    = "1961-02-13T20:06:35Z"
 )
 
+func setQuiet() error {
+	log.SetLevel(log.WarnLevel)
+	return nil
+}
+
 func newCli() *flags.Parser {
 	opts := cliOpts{
 		VersionFlag: func() error {
@@ -39,10 +44,7 @@ func newCli() *flags.Parser {
 				Message: fmt.Sprintf("version %s\ncommit %s\ndate %s\n", version, commit, date),
 			}
 		},
-		Quiet: func() error {
-			log.SetLevel(log.WarnLevel)
-			return nil
-		},
+		Quiet: setQuiet,
 	}
 	parser := flags.NewParser(&opts, flags.HelpFlag|flags.PassDoubleDash)
 	parser.LongDescription = "What would Henry Rollins do?"

--- a/cli_test.go
+++ b/cli_test.go
@@ -46,6 +46,17 @@ func TestCliListSuccess(t *testing.T) {
 	}
 }
 
+func TestCliQuiet(t *testing.T) {
+	initial := log.GetLevel()
+	defer log.SetLevel(initial)
+
+	err := setQuiet()
+	assert.NoError(t, err)
+
+	after := log.GetLevel()
+	assert.Equal(t, log.WarnLevel, after)
+}
+
 func TestCliCheck(t *testing.T) {
 	parser := newCli()
 	var out = &bytes.Buffer{}


### PR DESCRIPTION
This PR adds a quiet flag, `-q`, which disables outputting all the accepted packages.